### PR TITLE
Allow custom model for deterministic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@
 
 language: R
 cache: packages
+
+addons:
+  apt:
+    packages:
+      - libv8-dev
 r_github_packages:
   - mrc-ide/dde
 r_packages:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Suggests:
 RoxygenNote: 7.1.0
 Imports: 
     odin,
+    odin.js,
     dde (>= 1.0.2),
     dplyr,
     tidyr,
@@ -36,4 +37,6 @@ Imports:
     ggplot2
 Depends: R (>= 3.1.0)
 VignetteBuilder: knitr
-Remotes: mrc-ide/dde
+Remotes:
+    mrc-ide/dde,
+    mrc-ide/odin.js

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: squire
 Type: Package
 Title: SEIR transmission model of COVID-19
-Version: 0.4.4
+Version: 0.4.5
 Authors@R: c(
   person("Patrick", "Walker", email = "patrick.walker06@imperial.ac.uk", role = c("aut")),
   person("OJ", "Watson", email = "o.watson15@imperial.ac.uk", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# squire 0.4.5
+
+* Add functionality for running the deterministic model in javascript
+
 # squire 0.4.4
 
 * Patch for `calibrate` to ensure correct dt values provided

--- a/R/run.R
+++ b/R/run.R
@@ -313,6 +313,8 @@ run_explicit_SEEIR_model <- function(
 #' @param time_period Length of simulation. Default = 365
 #' @param hosp_bed_capacity General bed capacity. Can be single number of vector if capacity time-varies.
 #' @param ICU_bed_capacity ICU bed capacity. Can be single number of vector if capacity time-varies.
+#' @param mod_gen An odin model generation function. Default:
+#' `explicit_SEIR_deterministic`
 #' @param ... Other arguments to pass to \code{\link{parameters_explicit_SEEIR}}
 #'
 #' @return Simulation output
@@ -322,7 +324,7 @@ run_explicit_SEEIR_model <- function(
 #' \dontrun{
 #' pop <- get_population("Afghanistan")
 #' m <- get_mixing_matrix("Afghanistan")
-#' run_deterministic_SEIR_model(pop$n, m, [0, 50], [3, 3/2], 365, 100000,
+#' run_deterministic_SEIR_model(pop$n, m, c(0, 50), c(3, 3/2), 365, 100000,
 #' 1000000)
 #' }
 run_deterministic_SEIR_model <- function(
@@ -333,6 +335,7 @@ run_deterministic_SEIR_model <- function(
   time_period,
   hosp_bed_capacity,
   ICU_bed_capacity,
+  mod_gen = explicit_SEIR_deterministic,
   ...
   ) {
 
@@ -403,13 +406,13 @@ run_deterministic_SEIR_model <- function(
     p_dist = default_params$p_dist,
     hosp_bed_capacity = hosp_bed_capacity,
     ICU_bed_capacity = ICU_bed_capacity,
-    tt_matrix = default_params$tt_matrix,
+    tt_matrix = I(default_params$tt_matrix),
     mix_mat_set = default_params$mix_mat_set,
-    tt_beta = default_params$tt_beta,
-    beta_set = default_params$beta_set
+    tt_beta = I(default_params$tt_beta),
+    beta_set = I(default_params$beta_set)
   )
 
-  mod <- explicit_SEIR_deterministic(user = pars)
+  mod <- mod_gen(user = pars)
   t <- seq(from = 0, to = time_period - 1)
   results <- mod$run(t)
   out <- list(output = results, parameters = pars, model = mod)

--- a/R/util.R
+++ b/R/util.R
@@ -21,7 +21,7 @@ squire_file <- function(path) {
 #' @noRd
 odin_index <- function(model) {
   n_out <- environment(model$initialize)$private$n_out %||% 0
-  n_state <- length(model$initial())
+  n_state <- length(model$initial(0))
   model$transform_variables(seq_len(1L + n_state + n_out))
 }
 

--- a/man/contact_matrices.Rd
+++ b/man/contact_matrices.Rd
@@ -4,9 +4,7 @@
 \name{contact_matrices}
 \alias{contact_matrices}
 \title{Contact matrices}
-\format{
-A list of contact matrices
-}
+\format{A list of contact matrices}
 \usage{
 contact_matrices
 }

--- a/man/country_specific_healthcare_capacity.Rd
+++ b/man/country_specific_healthcare_capacity.Rd
@@ -4,9 +4,7 @@
 \name{country_specific_healthcare_capacity}
 \alias{country_specific_healthcare_capacity}
 \title{Country specific healthcare capacity}
-\format{
-A data.frame
-}
+\format{A data.frame}
 \usage{
 country_specific_healthcare_capacity
 }

--- a/man/income_group.Rd
+++ b/man/income_group.Rd
@@ -4,9 +4,7 @@
 \name{income_group}
 \alias{income_group}
 \title{Income group}
-\format{
-A data.frame
-}
+\format{A data.frame}
 \usage{
 income_group
 }

--- a/man/income_strata_healthcare_capacity.Rd
+++ b/man/income_strata_healthcare_capacity.Rd
@@ -4,9 +4,7 @@
 \name{income_strata_healthcare_capacity}
 \alias{income_strata_healthcare_capacity}
 \title{Income strata healthcare capacity}
-\format{
-A data.frame
-}
+\format{A data.frame}
 \usage{
 income_strata_healthcare_capacity
 }

--- a/man/population.Rd
+++ b/man/population.Rd
@@ -4,9 +4,7 @@
 \name{population}
 \alias{population}
 \title{Population}
-\format{
-A data.frame
-}
+\format{A data.frame}
 \usage{
 population
 }

--- a/man/run_deterministic_SEIR_model.Rd
+++ b/man/run_deterministic_SEIR_model.Rd
@@ -12,6 +12,7 @@ run_deterministic_SEIR_model(
   time_period,
   hosp_bed_capacity,
   ICU_bed_capacity,
+  mod_gen = explicit_SEIR_deterministic,
   ...
 )
 }
@@ -31,6 +32,9 @@ which will cause population to be sourced from \code{country}}
 
 \item{ICU_bed_capacity}{ICU bed capacity. Can be single number of vector if capacity time-varies.}
 
+\item{mod_gen}{An odin model generation function. Default:
+`explicit_SEIR_deterministic`}
+
 \item{...}{Other arguments to pass to \code{\link{parameters_explicit_SEEIR}}}
 }
 \value{
@@ -43,7 +47,7 @@ Run the deterministic explicit SEIR model
 \dontrun{
 pop <- get_population("Afghanistan")
 m <- get_mixing_matrix("Afghanistan")
-run_deterministic_SEIR_model(pop$n, m, [0, 50], [3, 3/2], 365, 100000,
+run_deterministic_SEIR_model(pop$n, m, c(0, 50), c(3, 3/2), 365, 100000,
 1000000)
 }
 }

--- a/tests/testthat/test-js.R
+++ b/tests/testthat/test-js.R
@@ -1,0 +1,41 @@
+context("js")
+
+test_that("js and R versions agree for basic model", {
+  pop <- get_population("Afghanistan")
+  m <- get_mixing_matrix("Afghanistan")
+  r_result <- run_deterministic_SEIR_model(
+    pop$n,
+    m,
+    c(0, 50),
+    c(3, 3/2),
+    365,
+    100000,
+    1000000
+  )
+
+  path <- system.file(
+    file.path('odin', 'explicit_SEIR_deterministic.R'),
+    package = "squire",
+    mustWork = TRUE
+  )
+  gen_js <- odin.js::odin_js(path)
+
+  js_result <- run_deterministic_SEIR_model(
+    pop$n,
+    m,
+    c(0, 50),
+    c(3, 3/2),
+    365,
+    100000,
+    1000000,
+    mod_gen = gen_js
+  )
+
+  ## Awkward syntax here to drop the deSolve additional information
+  ## off of the matrix (mod_r) so that it's easier to compare the
+  ## numbers with the js version
+  expect_equivalent(
+    js_result$output,
+    r_result$output[],
+    tolerance = 1e-4)
+})


### PR DESCRIPTION
This PR allows us to execute the deterministic model in javascript from R.

This allows us to easily create test cases using the javascript solvers and dismiss any approximation errors.

An example of how to do this is in [tests/testthat/test-js.R](https://github.com/mrc-ide/squire/pull/92/files#diff-d4870cc814e8cf01e42af67a4beeab8aR1)