### PR TITLE
Deterministic timing and output formatting

### DIFF
--- a/R/format_output.R
+++ b/R/format_output.R
@@ -5,6 +5,7 @@
 #' @return Formatted long data.frame
 #' @export
 format_deterministic_output <- function(x) {
+  x$output <- x$output[,,1,drop=TRUE]
   index <- odin_index(x$model)
 
   hospital_demand = c(

--- a/R/run.R
+++ b/R/run.R
@@ -397,10 +397,10 @@ run_deterministic_SEIR_model <- function(
   # create parameter list
   pars <- parameters_explicit_SEEIR(country=country,
                                     population=population,
-                                    tt_contact_matrix=tt_contact_matrix,
+                                    tt_contact_matrix=tt_contact_matrix*dt,
                                     contact_matrix_set=contact_matrix_set,
                                     R0=R0,
-                                    tt_R0=tt_R0,
+                                    tt_R0=tt_R0*dt,
                                     beta_set=beta_set,
                                     time_period=time_period,
                                     dt=dt,
@@ -427,8 +427,8 @@ run_deterministic_SEIR_model <- function(
                                     dur_rec=dur_rec,
                                     hosp_bed_capacity=hosp_bed_capacity,
                                     ICU_bed_capacity=ICU_bed_capacity,
-                                    tt_hosp_beds=tt_hosp_beds,
-                                    tt_ICU_beds=tt_ICU_beds)
+                                    tt_hosp_beds=tt_hosp_beds*dt,
+                                    tt_ICU_beds=tt_ICU_beds*dt)
 
   # handling time variables for js
   pars$tt_beta <- I(pars$tt_beta)

--- a/tests/testthat/test-output.R
+++ b/tests/testthat/test-output.R
@@ -8,28 +8,25 @@ test_that("deterministic output format works", {
       hosp_bed_capacity = 100000,
       ICU_bed_capacity = 1000000)
 
-  # put in to keep this going
-  model_output$output <- model_output$output[,,1,drop=TRUE]
-
   # reset output
-  model_output$output[,2:dim(model_output$output)[[2]]] <- 0
+  model_output$output[,2:dim(model_output$output)[[2]],1] <- 0
 
   # mock deaths
-  model_output$output[1, c('D[2]')] <- 2
-  model_output$output[2, c('D[10]')] <- 2
-  model_output$output[2, c('D[16]')] <- 5
+  model_output$output[1, c('D[2]'), 1] <- 2
+  model_output$output[2, c('D[10]'), 1] <- 2
+  model_output$output[2, c('D[16]'), 1] <- 5
 
   # mock infections
-  model_output$output[1, c('IMild[17]')] <- 4
-  model_output$output[2, c('IMild[2]', 'ICase1[5]')] <- 5
+  model_output$output[1, c('IMild[17]'), 1] <- 4
+  model_output$output[2, c('IMild[2]', 'ICase1[5]'), 1] <- 5
 
   # mock beds
-  model_output$output[1, c('IOxGetLive1[10]')] <- 2
-  model_output$output[2, c('IOxGetLive2[7]', 'IOxNotGetLive2[3]')] <- 3
+  model_output$output[1, c('IOxGetLive1[10]'), 1] <- 2
+  model_output$output[2, c('IOxGetLive2[7]', 'IOxNotGetLive2[3]'), 1] <- 3
 
   # mock icu
-  model_output$output[1, c('IMVGetLive1[10]')] <- 1
-  model_output$output[2, c('IMVGetLive2[7]', 'IMVNotGetLive2[3]')] <- 2
+  model_output$output[1, c('IMVGetLive1[10]'), 1] <- 1
+  model_output$output[2, c('IMVGetLive2[7]', 'IMVNotGetLive2[3]'), 1] <- 2
 
   actual <- format_deterministic_output(model_output)
   vars <- c('deaths','infections','hospital_demand','ICU_demand')


### PR DESCRIPTION
Two small adjustments to allow `run_deterministic_SEIR_model()` to be more easily used directly

1. Corrects timings for `tt_` arguments in `run_deterministic_SEIR_model()` that are modified using the general `parameters_explicit_SEEIR()` within that function. (Multiplies tham by dt to negate their later division by dt).

2. Allows the direct use of `format_deterministic_output()` on output of `run_deterministic_SEIR_model()` by reducing the output array from 3D to 2D within `format_deterministic_output()`. This also involved a slight tweak to the testing of that output to accommodate the change.

Am not 100% clued in as to all downstream uses of all  this functionality so worth a careful check. All tests within package passing though.