### PR TITLE
bump ODIN version in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Suggests:
     rmarkdown
 RoxygenNote: 7.1.0
 Imports: 
-    odin (>= 1.0.3), 
+    odin (>= 1.0.5), 
     dde (>= 1.0.2),
     dplyr,
     tidyr,


### PR DESCRIPTION
As part of ongoing development of new model update (not yet pushed), ODIN has been updated and so this PR bumps the DESCRIPTION to ensure the most up-to-date version of ODIN is installed when installing the package. 